### PR TITLE
added parse parameter to API post

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,7 +18,7 @@ def parse_join(message):
         x = requests.get("https://slack.com/api/im.open?token="+TOKEN+"&user="+m["user"]["id"])
         x = x.json()
         x = x["channel"]["id"]
-        xx = requests.post("https://slack.com/api/chat.postMessage?token="+TOKEN+"&channel="+x+"&text="+urllib.quote(MESSAGE)+"&as_user=true")
+        xx = requests.post("https://slack.com/api/chat.postMessage?token="+TOKEN+"&channel="+x+"&text="+urllib.quote(MESSAGE)+"&parse=full&as_user=true")
 
         #DEBUG
         #print '\033[91m' + "HELLO SENT" + m["user"]["id"] + '\033[0m'


### PR DESCRIPTION
with "parse=full" being passed, the user can post any messages using #, @ or links without having to format them in the message. When "parse=full" is received Slack will search the message and add the proper formatting.

I noticed this when I used the bot for my own Slack group, and the mentions weren't working (I'd use a #channel or @ a user and it'd just be plain text in the message).