### PR TITLE
Add option to unfurl links based on environment variable 'UNFURL-LINKS', default to TRUE

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,11 +11,13 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 ###VARIABLES THAT YOU NEED TO SET MANUALLY IF NOT ON HEROKU#####
 try:
-	MESSAGE = os.environ['WELCOME-MESSAGE'] 
-	TOKEN = os.environ['SLACK-TOKEN']
+        MESSAGE = os.environ['WELCOME-MESSAGE']
+        TOKEN = os.environ['SLACK-TOKEN']
+        UNFURL = os.environ['UNFURL-LINKS']
 except:
-	MESSAGE = 'Manually set the Message if youre not running through heroku or have not set vars in ENV'
-	TOKEN = 'Manually set the API Token if youre not running through heroku or have not set vars in ENV'
+        MESSAGE = 'Manually set the Message if youre not running through heroku or have not set vars in ENV'
+        TOKEN = 'Manually set the API Token if youre not running through heroku or have not set vars in ENV'
+        UNFURL = 'FALSE'
 ###############################################################
 
 def parse_join(message):
@@ -24,13 +26,15 @@ def parse_join(message):
         x = requests.get("https://slack.com/api/im.open?token="+TOKEN+"&user="+m["user"]["id"])
         x = x.json()
         x = x["channel"]["id"]
-        xx = requests.post("https://slack.com/api/chat.postMessage?token="+TOKEN+"&channel="+x+"&text="+urllib.quote(MESSAGE)+"&parse=full&as_user=true")
-
+        if (UNFURL.lower() == "false"):
+          xx = requests.post("https://slack.com/api/chat.postMessage?token="+TOKEN+"&channel="+x+"&text="+urllib.quote(MESSAGE)+"&parse=full&as_user=true&unfurl_links=false")
+        else:
+          xx = requests.post("https://slack.com/api/chat.postMessage?token="+TOKEN+"&channel="+x+"&text="+urllib.quote(MESSAGE)+"&parse=full&as_user=true")
         #DEBUG
         #print '\033[91m' + "HELLO SENT" + m["user"]["id"] + '\033[0m'
         #
 
-#Connects to Slacks and initiates socket handshake        
+#Connects to Slacks and initiates socket handshake
 def start_rtm():
     r = requests.get("https://slack.com/api/rtm.start?token="+TOKEN, verify=False)
     r = r.json()
@@ -55,3 +59,4 @@ if __name__ == "__main__":
     ws = websocket.WebSocketApp(r, on_message = on_message, on_error = on_error, on_close = on_close)
     #ws.on_open
     ws.run_forever()
+


### PR DESCRIPTION
Currently if the welcome message contains multiple links, slack will unfurl them all at the end of the welcome message. This creates a rather spammy message with previews of each link included. This adds a boolean environment variable, UNFURL-LINKS, that allows the user to toggle this behavior on/off, defaulting to the original behavior of unfurling all links.

Slack will still unfurl the first link found in the message, but it creates a much cleaner message for the end user. 