### PR TITLE
Replaced Deprecated Slack API request with newer API calls to resolve #24   

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you have questions open an `Issue` (preferred) or reply to the tutorial artic
 
 # Requirements
 Python 2.7+
-Edit `bot.py` on lines 7-8 to customise with your greeting and token
+Edit `bot.py` on lines 27-29 to customise with your greeting and token
 
 # Installation
 ```bash

--- a/bot.py
+++ b/bot.py
@@ -35,7 +35,7 @@ def is_team_join(msg):
 def is_debug_channel_join(msg):
     return msg['type'] == "member_joined_channel" and msg['channel'] == DEBUG_CHANNEL_ID and msg['channel_type'] == 'C'
 
-def is_direct_message(msg): 
+def is_direct_message(msg):
     print(msg)
     is_bot = False
     if 'bot_id' in msg:
@@ -56,7 +56,7 @@ def parse_join(message):
     if is_team_join(m) or is_debug_channel_join(m):
         user_id = m["user"]["id"] if is_team_join(m) else m["user"]
         logging.debug(m)
-        conversation = requests.post("https://slack.com/api/conversations.open?token=" + TOKEN + "&users=" + "UL5JGPBC2",
+        conversation = requests.post("https://slack.com/api/conversations.open?token=" + TOKEN + "&users=" + user_id,
                           data=None).json()
         conversation_channel = conversation["channel"]["id"]
         logging.debug(conversation_channel)
@@ -85,14 +85,14 @@ def parse_join(message):
 
         # Need to get the display name from the user_id
         real_name = get_display_name(user_id)
-				
+
         #logging.DEBUG('SENDING MESSAGE: '+user_message+' TO USER '+real_name)
         # Need to send a message to a channel
         requests.get("https://slack.com/api/chat.postMessage?token="+CHANNEL_TOKEN+"&channel="+RESPONSE_CHANNEL+"&text="+user_message+"&as_user=false&username="+real_name)
 
 #Connects to Slacks and initiates socket handshake
 def start_rtm():
-    
+
     r = requests.get("https://slack.com/api/rtm.start?token="+TOKEN, verify=False)
     r = r.json()
     logging.info(r)

--- a/bot.py
+++ b/bot.py
@@ -21,7 +21,7 @@ try:
         TOKEN = os.environ.get('SLACK_TOKEN')
         CHANNEL_TOKEN = os.environ.get('CHANNEL_TOKEN')
         UNFURL = os.environ.get('UNFURL_LINKS')
-	RESPONSE_CHANNEL = os.environ.get('RESPONSE_CHANNEL')
+        RESPONSE_CHANNEL = os.environ.get('RESPONSE_CHANNEL')
         DEBUG_CHANNEL_ID = os.environ.get('DEBUG_CHANNEL_ID', False)
 except:
         MESSAGE = 'Manually set the Message if youre not running through heroku or have not set vars in ENV'
@@ -36,7 +36,7 @@ def is_debug_channel_join(msg):
     return msg['type'] == "member_joined_channel" and msg['channel'] == DEBUG_CHANNEL_ID and msg['channel_type'] == 'C'
 
 def is_direct_message(msg): 
-    print msg
+    print(msg)
     is_bot = False
     if 'bot_id' in msg:
         is_bot = True
@@ -56,14 +56,14 @@ def parse_join(message):
     if is_team_join(m) or is_debug_channel_join(m):
         user_id = m["user"]["id"] if is_team_join(m) else m["user"]
         logging.debug(m)
-        x = requests.get("https://slack.com/api/im.open?token="+TOKEN+"&user="+user_id)
-        x = x.json()
-        x = x["channel"]["id"]
-        logging.debug(x)
+        conversation = requests.post("https://slack.com/api/conversations.open?token=" + TOKEN + "&users=" + "UL5JGPBC2",
+                          data=None).json()
+        conversation_channel = conversation["channel"]["id"]
+        logging.debug(conversation_channel)
 
         data = {
                 'token': TOKEN,
-                'channel': x,
+                'channel': conversation_channel,
                 'text': MESSAGE,
                 'parse': 'full',
                 'as_user': 'true',
@@ -72,9 +72,9 @@ def parse_join(message):
         logging.debug(data)
 
         if (UNFURL.lower() == "false"):
-          data = data.update({'unfurl_link': 'false'})
+          data.update({'unfurl_link': 'false'})
 
-        xx = requests.post("https://slack.com/api/chat.postMessage", data=data)
+        post_message_response = requests.post("https://slack.com/api/chat.postMessage", data=data)
         logging.debug('\033[91m' + "HELLO SENT TO " + m["user"]["id"] + '\033[0m')
 
     if is_direct_message(m):


### PR DESCRIPTION
PR to resolve #24 
Changes:
1. updated deprecated slack api call(`https://slack.com/api/im.open`) with `https://slack.com/api/conversations.open`.
2. Fixed bug on line 75 which was setting dictionary data to None in case `UNFURL=False`  because dictionary.update returns None, and re-assignment is not required.
3. changed variable name to be more descriptive on line number 59 and 77
4. Minor README.md edits to reflect changes in bot.py